### PR TITLE
Improve README with usage info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # lost-but-i-found
+
+This project identifies songs in video or audio files using [Shazam](https://github.com/sergree/shazamio). The script extracts audio with FFmpeg, sends it to Shazam for recognition and writes the matches to a text file. File dialogs are provided via Tkinter so you can choose the input and where to save the results.
+
+## Requirements
+
+- Python 3
+- The `ffmpeg` command line tool must be installed and available in your `PATH`.
+- Python packages:
+  - `ffmpeg-python`
+  - `shazamio`
+  - `tkinter` (included with most Python installs)
+
+Install the dependencies with `pip`:
+
+```bash
+pip install ffmpeg-python shazamio
+```
+
+## Usage
+
+Run the main script and follow the dialogs to select the video folder and the output file:
+
+```bash
+python shazam.py
+```
+
+For extra logs during processing, pass `--verbose`:
+
+```bash
+python shazam.py --verbose
+```


### PR DESCRIPTION
## Summary
- expand README with project overview
- document Python dependencies
- show example usage including `--verbose`

## Testing
- `python3 -m py_compile shazam.py`


------
https://chatgpt.com/codex/tasks/task_e_6863e864024c832dbd038123c5c3074e