### PR TITLE
Fix Tk root handling in file dialogs

### DIFF
--- a/shazam.py
+++ b/shazam.py
@@ -14,12 +14,16 @@ args = parser.parse_args()
 def selecionar_pasta(titulo):
     root = tk.Tk()
     root.withdraw()
-    return filedialog.askdirectory(title=titulo)
+    pasta = filedialog.askdirectory(title=titulo)
+    root.destroy()
+    return pasta
 
 def selecionar_arquivo(titulo):
     root = tk.Tk()
     root.withdraw()
-    return filedialog.asksaveasfilename(title=titulo, defaultextension=".txt", filetypes=[("Arquivos de texto", "*.txt")])
+    arquivo = filedialog.asksaveasfilename(title=titulo, defaultextension=".txt", filetypes=[("Arquivos de texto", "*.txt")])
+    root.destroy()
+    return arquivo
 
 async def reconhecer_musica(audio_path):
     shazam = Shazam()


### PR DESCRIPTION
## Summary
- ensure Tk root windows are destroyed after dialog use in `shazam.py`

## Testing
- `python -m py_compile shazam.py`


------
https://chatgpt.com/codex/tasks/task_e_6863e8850800832d92ae3796561fdc37